### PR TITLE
Fix Save writing to the wrong file

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -261,6 +261,7 @@ bool DDOPGeneratorGUI::render_menu_bar()
 			{
 				shouldShowNewDDOP = true;
 
+				lastFileName.clear();
 				currentObjectPool.reset();
 				currentPoolValid = false;
 				currentObjectPool = std::make_unique<isobus::DeviceDescriptorObjectPool>();
@@ -286,7 +287,16 @@ bool DDOPGeneratorGUI::render_menu_bar()
 			if (ImGui::MenuItem("Save", "Overwrite current DDOP file"))
 			{
 				FileDialog::file_dialog_open = false;
-				saveModal = true;
+
+				if (lastFileName.empty())
+				{
+					saveAsModal = true;
+					memset(filePathBuffer, 0, IM_ARRAYSIZE(filePathBuffer));
+				}
+				else
+				{
+					saveModal = true;
+				}
 			}
 			if (ImGui::MenuItem("Save as", "Save current DDOP to a file"))
 			{
@@ -296,6 +306,7 @@ bool DDOPGeneratorGUI::render_menu_bar()
 			}
 			if (ImGui::MenuItem("Close", "Closes the active file"))
 			{
+				lastFileName.clear();
 				currentObjectPool.reset();
 				currentPoolValid = false;
 			}
@@ -480,7 +491,6 @@ void DDOPGeneratorGUI::render_open_file_menu()
 	else if (openFileDialogue)
 	{
 		std::string selectedFileToRead(filePathBuffer);
-		lastFileName = selectedFileToRead;
 		memset(filePathBuffer, 0, FILE_PATH_BUFFER_MAX_LENGTH);
 		openFileDialogue = false;
 
@@ -508,10 +518,12 @@ void DDOPGeneratorGUI::render_open_file_menu()
 				{
 					// Valid pool?
 					currentPoolValid = true;
+					lastFileName = selectedFileToRead;
 				}
 				else
 				{
 					currentObjectPool.reset();
+					currentPoolValid = false;
 
 					ImGui::OpenPopup("Error Loading DDOP");
 				}
@@ -1845,7 +1857,7 @@ void DDOPGeneratorGUI::render_save()
 	bool shouldShowSaveSucceeded = false;
 	if (ImGui::BeginPopupModal("##Save Modal", NULL, ImGuiWindowFlags_AlwaysAutoResize))
 	{
-		ImGui::Text("Are you sure you want to overwrite your DDOP file?");
+		ImGui::Text("Are you sure you want to overwrite %s?", lastFileName.c_str());
 		ImGui::Separator();
 		if (ImGui::Button("Save", ImVec2(120, 0)))
 		{
@@ -1926,6 +1938,7 @@ void DDOPGeneratorGUI::render_save()
 					if (outFile)
 					{
 						outFile.write(reinterpret_cast<char *>(binaryDDOP.data()), binaryDDOP.size());
+						lastFileName = fileName;
 						shouldShowSaveSucceeded = true;
 					}
 					else


### PR DESCRIPTION
`lastFileName` is set only when a file is opened, and it is set before we know the load succeeded. So `File → Save` writes to the wrong file:

- Open A, then `Save as` B, then `Save`. It overwrites A, not B.
- `New`, then `Save`. It overwrites the file which was opened before, or writes to `""` if nothing was opened.
- If the load fails, `currentPoolValid` stays `true`, so `Save` dereferences a null pool and the app crashes.

Now `lastFileName` follows the file which backs the current pool. It is set after a successful open and after a successful `Save as`, and cleared by `New` and `Close`. If there is no backing file, `Save` opens the `Save as` dialog instead of guessing a target. The confirm dialog also names the file now.

The load failure path sets `currentPoolValid = false` too. It is the same stale state problem, one line away.

Tested on sim, comparing a build of `main` against this branch. Same steps and same files on both:
- Open A, `Save as` B, delete B, then `Save`. On `main` it rewrites A and B is not recreated. On this branch it recreates B and A is not touched.
- `New`, then `Save`. On `main` it overwrites A with the empty pool. On this branch it opens `Save as`.
- Open a corrupt `.iop`, then `Save`. On `main` it segfaults. On this branch `Save` is disabled.