### PR TITLE
Add ISOXML TASKDATA.XML export to the File menu

### DIFF
--- a/include/gui.hpp
+++ b/include/gui.hpp
@@ -92,6 +92,7 @@ private:
 	bool openFileDialogue = false;
 	bool saveModal = false;
 	bool saveAsModal = false;
+	bool exportModal = false;
 	bool currentPoolValid = false;
 };
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -17,7 +17,9 @@
 #include "isobus/isobus/isobus_data_dictionary.hpp"
 #include "logsink.hpp"
 
+#include <cerrno>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <sstream>
 
@@ -146,6 +148,12 @@ void DDOPGeneratorGUI::start()
 		if ((saveModal != prevSaveModalState))
 		{
 			ImGui::OpenPopup("##Save Modal");
+		}
+
+		if (exportModal)
+		{
+			ImGui::OpenPopup("##Export Modal");
+			exportModal = false;
 		}
 
 		render_save();
@@ -302,6 +310,12 @@ bool DDOPGeneratorGUI::render_menu_bar()
 			{
 				FileDialog::file_dialog_open = false;
 				saveAsModal = true;
+				memset(filePathBuffer, 0, IM_ARRAYSIZE(filePathBuffer));
+			}
+			if (ImGui::MenuItem("Export as ISOXML", "Export current DDOP to an ISOXML TASKDATA.XML file"))
+			{
+				FileDialog::file_dialog_open = false;
+				exportModal = true;
 				memset(filePathBuffer, 0, IM_ARRAYSIZE(filePathBuffer));
 			}
 			if (ImGui::MenuItem("Close", "Closes the active file"))
@@ -1959,6 +1973,54 @@ void DDOPGeneratorGUI::render_save()
 		{
 			ImGui::CloseCurrentPopup();
 			saveAsModal = false;
+		}
+		ImGui::EndPopup();
+	}
+
+	if (ImGui::BeginPopupModal("##Export Modal", NULL, ImGuiWindowFlags_AlwaysAutoResize))
+	{
+		ImGui::Text("Enter file name");
+		ImGui::Separator();
+
+		ImGui::InputText("File Name", filePathBuffer, IM_ARRAYSIZE(filePathBuffer));
+
+		ImGui::SetItemDefaultFocus();
+		if (ImGui::Button("Export", ImVec2(120, 0)))
+		{
+			ImGui::CloseCurrentPopup();
+
+			if ((nullptr != currentObjectPool) && currentPoolValid)
+			{
+				std::string taskDataXML;
+				logger.logHistory.clear();
+
+				if (currentObjectPool->generate_task_data_iso_xml(taskDataXML))
+				{
+					const char *fileName = (0 == filePathBuffer[0]) ? "TASKDATA.XML" : filePathBuffer;
+
+					errno = 0;
+					std::ofstream outFile(fileName, std::ios_base::trunc);
+					outFile << taskDataXML;
+					outFile.close();
+
+					shouldShowSaveSucceeded = outFile.good();
+					shouldShowSaveFailed = !outFile.good();
+
+					if (shouldShowSaveFailed)
+					{
+						LOG_ERROR("[DDOP]: Could not write \"%s\": %s", fileName, (0 != errno) ? std::strerror(errno) : "unknown error");
+					}
+				}
+				else
+				{
+					shouldShowSaveFailed = true;
+				}
+			}
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("Cancel", ImVec2(120, 0)))
+		{
+			ImGui::CloseCurrentPopup();
 		}
 		ImGui::EndPopup();
 	}


### PR DESCRIPTION
## Describe your changes
Adds `File` -> `Export as ISOXML`, which writes the loaded DDOP out as an ISOXML `TASKDATA.XML` file.

`DeviceDescriptorObjectPool::generate_task_data_iso_xml()` is already in AgIsoStack++, but the generator never called it, so far the tool could only write the binary .iop.

- The item sits between `Save as` and `Close`, so it is disabled together with the other pool operations when no DDOP is loaded.
- The prompt asks for a file name and uses `TASKDATA.XML` when it is left empty. The file is written in text mode and lastFileName is not touched, so a later Save still overwrites the `.iop` which the pool came from.
- No TC version list box on the prompt, because the XML generator writes `VersionMajor="3"` itself no matter what the pool compatibility level is.
- Success and failure reuse the existing save dialogs. A failed write logs the reason, so the dialog shows for example `[DDOP]: Could not write "TASKDATA.XML": No space left on device`.

## How has this been tested?

I exported 11 real vendor DDOPs through the GUI, one application run each, and compared every produced file with what `generate_task_data_iso_xml()` returns for the same `.iop`. All 11 are byte identical.

Failure paths checked in the GUI: `EXAMPLE.iop`, which can not be serialized, a file name in a directory which does not exist, and `/dev/full`. Each one shows the failure dialog with the reason and writes no file.