### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(AgIsoDDOPGenerator
-        VERSION 1.0
+        VERSION 1.1.0
         LANGUAGES CXX
         DESCRIPTION "DDOP Generator based on AgIsoStack++"
 )


### PR DESCRIPTION
## Describe your changes
Bumps the project version in `CMakeLists.txt` from `1.0` to `1.1.0`. I would like to cut a 1.1.0 release after this merges.

The version was never touched since the first release. The `1.0/1.0.1` tag from 2023 did not get a version bump or a GitHub release either, so the releases page still shows 1.0.0 from three years ago while main is eight commits ahead of it.

## How has this been tested?
Configured and built on Linux with CMake 4.4:

```
cmake -S . -B build -DSDL_CCACHE=OFF
cmake --build build --target AgIsoDDOPGenerator -j$(nproc)
```
