### PR TITLE
Add a linting workflow, a MacOS build job, and update the CI actions to v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,26 @@ jobs:
              build/Release/*.dll
              build/Release/*.exe
 
+  macos_build:
+    name: MacOS Build
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: Compile
+        run: |
+          mkdir build
+          cmake -S . -B build -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCAN_DRIVER=None -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --config Release
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-executable
+          path: |
+            build/AgIsoDDOPGenerator
+
   ubuntu_build:
     name: Ubuntu Build
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Build
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   windows_build:
@@ -8,7 +13,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Compile
@@ -17,7 +22,7 @@ jobs:
           cmake -S . -B build -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCAN_DRIVER=None -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-executable
           path: |         
@@ -29,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Compile
@@ -39,7 +44,7 @@ jobs:
           cmake -S . -B build -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCAN_DRIVER=None -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-executable
           path: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.11
-          cache: "pip"
       - name: Install lint tool
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,41 @@
+name: Linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  clang-format:
+    name: clang-format style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Run clang-format style check for C/C++/Protobuf programs.
+        uses: jidicula/clang-format-action@v4.18.0
+        with:
+          clang-format-version: 19
+  cmake-format:
+    name: cmake-format style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.11
+          cache: "pip"
+      - name: Install lint tool
+        run: |
+          python -m pip install --upgrade pip
+          pip install cmake-format pyyaml
+      - name: Check cmake-lint
+        run: find . -name CMakeLists.txt | xargs cmake-lint
+      - name: Run cmake-format
+        run: find . -name CMakeLists.txt | xargs cmake-format -i
+      - name: Check cmake-format
+        run: git diff --patch-with-stat --exit-code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(AgIsoDDOPGenerator
-        VERSION 1.0
-        LANGUAGES CXX
-        DESCRIPTION "DDOP Generator based on AgIsoStack++"
-)
+project(
+  AgIsoDDOPGenerator
+  VERSION 1.0
+  LANGUAGES CXX
+  DESCRIPTION "DDOP Generator based on AgIsoStack++")
 
 add_executable(AgIsoDDOPGenerator)
 set_property(TARGET AgIsoDDOPGenerator PROPERTY CXX_STANDARD 17)
@@ -19,7 +19,7 @@ set(CPACK_PACKAGE_CONTACT "delgrossoengineering@protonmail.com")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/Open-Agriculture")
 set(CPACK_PACKAGE_VERSION ${CMAKE_PROJECT_VERSION})
 if(CPack_CMake_INCLUDED EQUAL 1)
-    include(CPack)
+  include(CPack)
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -30,44 +30,34 @@ set(BUILD_TESTING OFF)
 add_subdirectory(submodules/agisostack)
 add_subdirectory(submodules/sdl)
 
-target_sources(AgIsoDDOPGenerator
-               PRIVATE
-               src/main.cpp
-               src/gui.cpp
-            
-               submodules/imgui/imgui.cpp
-               submodules/imgui/imgui_demo.cpp
-               submodules/imgui/imgui_draw.cpp
-               submodules/imgui/imgui_tables.cpp
-               submodules/imgui/imgui_widgets.cpp
-               submodules/imgui/backends/imgui_impl_sdl2.cpp
-               submodules/imgui/backends/imgui_impl_opengl3.cpp
-)
+target_sources(
+  AgIsoDDOPGenerator
+  PRIVATE src/main.cpp
+          src/gui.cpp
+          submodules/imgui/imgui.cpp
+          submodules/imgui/imgui_demo.cpp
+          submodules/imgui/imgui_draw.cpp
+          submodules/imgui/imgui_tables.cpp
+          submodules/imgui/imgui_widgets.cpp
+          submodules/imgui/backends/imgui_impl_sdl2.cpp
+          submodules/imgui/backends/imgui_impl_opengl3.cpp)
 
-target_include_directories(AgIsoDDOPGenerator
-                           PUBLIC
-                           "include"
-                           submodules/imgui
-                           submodules/imgui/backends
-                           submodules/sdl/include
-)
+target_include_directories(
+  AgIsoDDOPGenerator PUBLIC "include" submodules/imgui
+                            submodules/imgui/backends submodules/sdl/include)
 
-target_link_libraries(AgIsoDDOPGenerator
-                      PRIVATE
-                      isobus::Isobus
-                      isobus::Utility
-                      OpenGL::GL
-                      SDL2 
-                      SDL2main
-                      ${CMAKE_DL_LIBS}
-)
+target_link_libraries(
+  AgIsoDDOPGenerator PRIVATE isobus::Isobus isobus::Utility OpenGL::GL SDL2
+                             SDL2main ${CMAKE_DL_LIBS})
 
 install(TARGETS AgIsoDDOPGenerator RUNTIME DESTINATION bin)
 
-if (WIN32)
-    add_custom_command(
-        TARGET AgIsoDDOPGenerator POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:SDL2::SDL2>" "$<TARGET_FILE_DIR:AgIsoDDOPGenerator>"
-        VERBATIM
-    )
+if(WIN32)
+  add_custom_command(
+    TARGET AgIsoDDOPGenerator
+    POST_BUILD
+    COMMENT "Copying SDL2.dll to the build directory"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:SDL2::SDL2>"
+            "$<TARGET_FILE_DIR:AgIsoDDOPGenerator>"
+    VERBATIM)
 endif()

--- a/include/L2DFileDialog.hpp
+++ b/include/L2DFileDialog.hpp
@@ -63,7 +63,8 @@ namespace FileDialog
 	static std::string getPathWithTrailingSeparator(const std::string &path)
 	{
 		std::string ret = path;
-		if (path.back() != dirSep) {
+		if (path.back() != dirSep)
+		{
 			ret += std::filesystem::path::preferred_separator;
 		}
 		return ret;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -13,8 +13,8 @@
 #include "imgui.h"
 #include "imgui_impl_opengl3.h"
 #include "imgui_impl_sdl2.h"
-#include "isobus/utility/iop_file_interface.hpp"
 #include "isobus/isobus/isobus_data_dictionary.hpp"
+#include "isobus/utility/iop_file_interface.hpp"
 #include "logsink.hpp"
 
 #include <cerrno>
@@ -1827,16 +1827,16 @@ std::string DDOPGeneratorGUI::get_object_type_string(isobus::task_controller_obj
 std::string DDOPGeneratorGUI::get_object_display_name(std::shared_ptr<isobus::task_controller_object::Object> object)
 {
 	std::string displayName = object->get_designator();
-	
+
 	// Early return if designator is not empty and not the default "Designator" text
 	if (!displayName.empty() && displayName != "Designator")
 	{
 		return displayName;
 	}
-	
+
 	// If designator is empty or default, use appropriate fallback based on object type
 	const auto objectType = object->get_object_type();
-	
+
 	if (objectType == isobus::task_controller_object::ObjectTypes::DeviceProcessData)
 	{
 		auto dpd = std::dynamic_pointer_cast<isobus::task_controller_object::DeviceProcessDataObject>(object);
@@ -1861,7 +1861,7 @@ std::string DDOPGeneratorGUI::get_object_display_name(std::shared_ptr<isobus::ta
 			displayName = get_element_type_string(det->get_type()) + " " + std::to_string(det->get_element_number());
 		}
 	}
-	
+
 	return displayName;
 }
 


### PR DESCRIPTION
The repo has `.clang-format` and `.cmake-format.yaml` but nothing in CI checking them, so I added the same linting workflow the other repos like VT and Stack use. Both workflows now run on main and on PRs, before this `build.yml` was on: push only so a PR from a fork got no build here. Also bumped checkout to v7 and upload-artifact to v7, and added a MacOS build.

The first commit is just `clang-format -i` and `cmake-format -i` output, otherwise the new lint job fails right away.