### PR TITLE
Attach working binaries to releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+  release:
+    types: [published]
 
 jobs:
   windows_build:
@@ -21,13 +23,14 @@ jobs:
           mkdir build
           cmake -S . -B build -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCAN_DRIVER=None -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release
+      - name: Package
+        run: Compress-Archive -Path build/Release/*.exe, build/Release/*.dll -DestinationPath windows-executable.zip
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7
         with:
           name: windows-executable
-          path: |         
-             build/Release/*.dll
-             build/Release/*.exe
+          path: windows-executable.zip
+          if-no-files-found: error
 
   macos_build:
     name: MacOS Build
@@ -42,17 +45,27 @@ jobs:
           mkdir build
           cmake -S . -B build -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCAN_DRIVER=None -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release
+      - name: Package
+        run: (cd build && tar -czf ../macos-executable.tar.gz AgIsoDDOPGenerator libSDL2*.dylib)
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7
         with:
           name: macos-executable
-          path: |
-            build/AgIsoDDOPGenerator
+          path: macos-executable.tar.gz
+          if-no-files-found: error
 
   ubuntu_build:
     name: Ubuntu Build
     runs-on: ubuntu-latest
+    # ubuntu-latest is now 24.04, whose glibc 2.39 links symbols that 22.04's glibc 2.35 does
+    # not have, so a binary built on the runner image will not start there. Building inside
+    # 22.04 keeps that floor pinned no matter what ubuntu-latest becomes next.
+    container: ubuntu:22.04
     steps:
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y build-essential cmake git ca-certificates libgl1-mesa-dev libxext-dev
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -60,12 +73,40 @@ jobs:
       - name: Compile
         run: |
           mkdir build
-          sudo apt-get install -y libgl1-mesa-dev libxext-dev
           cmake -S . -B build -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCAN_DRIVER=None -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release
+      - name: Package
+        run: tar -czf linux-executable.tar.gz -C build AgIsoDDOPGenerator
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7
         with:
           name: linux-executable
-          path: |
-            build/AgIsoDDOPGenerator
+          path: linux-executable.tar.gz
+          if-no-files-found: error
+
+  release_upload:
+    name: Release Packages
+    if: github.event_name == 'release'
+    needs: [windows_build, macos_build, ubuntu_build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download Packages
+        uses: actions/download-artifact@v7
+        with:
+          pattern: "*-executable"
+          merge-multiple: true
+      - name: Verify Packages
+        run: |
+          for os in linux macos; do
+            mkdir -p "verify/$os"
+            tar -xzf "$os-executable.tar.gz" -C "verify/$os"
+            test -x "verify/$os/AgIsoDDOPGenerator"
+          done
+      - name: Attach Packages To Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG" linux-executable.tar.gz macos-executable.tar.gz windows-executable.zip --clobber

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,7 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
-  release:
-    types: [published]
+  workflow_call:
 
 jobs:
   windows_build:
@@ -84,29 +83,3 @@ jobs:
           path: linux-executable.tar.gz
           if-no-files-found: error
 
-  release_upload:
-    name: Release Packages
-    if: github.event_name == 'release'
-    needs: [windows_build, macos_build, ubuntu_build]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Download Packages
-        uses: actions/download-artifact@v7
-        with:
-          pattern: "*-executable"
-          merge-multiple: true
-      - name: Verify Packages
-        run: |
-          for os in linux macos; do
-            mkdir -p "verify/$os"
-            tar -xzf "$os-executable.tar.gz" -C "verify/$os"
-            test -x "verify/$os/AgIsoDDOPGenerator"
-          done
-      - name: Attach Packages To Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG" linux-executable.tar.gz macos-executable.tar.gz windows-executable.zip --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+
+  release_upload:
+    name: Release Packages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download Packages
+        uses: actions/download-artifact@v7
+        with:
+          pattern: "*-executable"
+          merge-multiple: true
+      - name: Verify Packages
+        run: |
+          for os in linux macos; do
+            mkdir -p "verify/$os"
+            tar -xzf "$os-executable.tar.gz" -C "verify/$os"
+            test -x "verify/$os/AgIsoDDOPGenerator"
+          done
+      - name: Attach Packages To Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG" linux-executable.tar.gz macos-executable.tar.gz windows-executable.zip --clobber

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET
+    "11.0"
+    CACHE STRING "Minimum macOS version the binary supports")
+
 project(
   AgIsoDDOPGenerator
   VERSION 1.1.0
@@ -52,12 +56,26 @@ target_link_libraries(
 
 install(TARGETS AgIsoDDOPGenerator RUNTIME DESTINATION bin)
 
-if(WIN32)
+if(WIN32 OR APPLE)
   add_custom_command(
     TARGET AgIsoDDOPGenerator
     POST_BUILD
-    COMMENT "Copying SDL2.dll to the build directory"
+    COMMENT "Copying the SDL2 library to the build directory"
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:SDL2::SDL2>"
             "$<TARGET_FILE_DIR:AgIsoDDOPGenerator>"
     VERBATIM)
 endif()
+
+if(APPLE)
+  set(RUNTIME_SEARCH_PATH "@executable_path")
+else()
+  set(RUNTIME_SEARCH_PATH "\$ORIGIN/submodules/sdl")
+endif()
+
+# The rpath CMake computes is the absolute build directory plus an empty entry,
+# which the loader reads as the current working directory - a released binary
+# would load libSDL2 from whatever folder it was started in. Both paths here are
+# relative to the executable instead.
+set_target_properties(
+  AgIsoDDOPGenerator PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                                INSTALL_RPATH "${RUNTIME_SEARCH_PATH}")

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ When used in combination with AgIsoStack (or any other TC client), it provides a
 * Basic object pool error checking to help you find errors before loading onto a TC
 * Completely free and open source alternative to many paid products!
 
+### Releases
+
+Prebuilt binaries for Windows, Linux and macOS 11+ (Apple Silicon) are attached to every [release](https://github.com/Open-Agriculture/AgIsoDDOPGenerator/releases).
+
+The Linux binary links SDL2 and OpenGL dynamically and does not bundle them:
+
+```
+sudo apt install libsdl2-2.0-0 libopengl0
+```
+
+The macOS binary is unsigned, so Gatekeeper quarantines it on download. Keep it in the same folder as the `libSDL2-2.0.0.dylib` from the same archive, and clear the quarantine flag:
+
+```
+xattr -dr com.apple.quarantine AgIsoDDOPGenerator
+```
+
 ### Compilation
 
 This project is built with CMake.


### PR DESCRIPTION
The release page has no binaries attached, and the Linux `1.1.0` release exe was not working for me. Three fixes:

- CI never uploaded anything, so there is a job now that attaches the Windows, Linux and macOS zips when a release is published.
- Linux was built on `ubuntu-latest` (v22.04 - 3 years ago), which is v24.04 now, so it links glibc 2.39 symbols and can not start on 22.04. It builds in a `ubuntu:22.04` container now to make sure it runs on both 22.04 and 24.04 versions.
- The binary had an empty rpath entry, which the loader reads as the current directory, so it would load `libSDL2` from whatever folder you started it in. It is `$ORIGIN/submodules/sdl` now, `@executable_path` on macOS.

 Each build job now packs its own archive instead: .tar.gz for Linux and MacOS, since modes live inside the tarball where nothing in the pipeline can flatten them, and .zip for Windows.

The upload job only runs on release: published, and the README now covers the SDL2/OpenGL packages Linux needs and the Gatekeeper quarantine on MacOS.