### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET
 
 project(
   AgIsoDDOPGenerator
-  VERSION 1.1.0
+  VERSION 1.1.1
   LANGUAGES CXX
   DESCRIPTION "DDOP Generator based on AgIsoStack++")
 


### PR DESCRIPTION
## Describe your changes
Bumps the project version in `CMakeLists.txt` from `1.1.0` to `1.1.1`, so the release binaries built off `main` after #22 report the right version. Will do a small 1.1.1 release after this merges to verify the new binary-attachment workflow end to end.
