### PR TITLE
Show DDI name in the editor

### DIFF
--- a/include/gui.hpp
+++ b/include/gui.hpp
@@ -31,6 +31,8 @@ private:
 	void parseElementChildrenOfElement(std::uint16_t objectID);
 	void parseChildren(std::shared_ptr<isobus::task_controller_object::DeviceElementObject> element);
 	void render_object_tree();
+	template<typename T>
+	void render_ddi_setting(std::shared_ptr<T> object);
 	void render_device_settings(std::shared_ptr<isobus::task_controller_object::DeviceObject> object);
 	void render_device_element_settings(std::shared_ptr<isobus::task_controller_object::DeviceElementObject> object);
 	void render_device_process_data_settings(std::shared_ptr<isobus::task_controller_object::DeviceProcessDataObject> object);

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -715,6 +715,25 @@ void DDOPGeneratorGUI::render_object_tree()
 	}
 }
 
+template<typename T>
+void DDOPGeneratorGUI::render_ddi_setting(std::shared_ptr<T> object)
+{
+	ImGui::InputInt("DDI", &ddiBuffer);
+	if (ddiBuffer < 0)
+	{
+		ddiBuffer = 0;
+	}
+	else if (ddiBuffer > 0xFFFF)
+	{
+		ddiBuffer = 0xFFFF;
+	}
+
+	if (ddiBuffer != object->get_ddi())
+	{
+		object->set_ddi(ddiBuffer);
+	}
+}
+
 void DDOPGeneratorGUI::render_device_settings(std::shared_ptr<isobus::task_controller_object::DeviceObject> object)
 {
 	ImGui::InputText("Designator", designatorBuffer, IM_ARRAYSIZE(designatorBuffer));
@@ -1125,20 +1144,7 @@ void DDOPGeneratorGUI::render_device_process_data_settings(std::shared_ptr<isobu
 		object->set_designator(designator);
 	}
 
-	ImGui::InputInt("DDI", &ddiBuffer);
-	if (ddiBuffer < 0)
-	{
-		ddiBuffer = 0;
-	}
-	else if (ddiBuffer > 0xFFFF)
-	{
-		ddiBuffer = 0xFFFF;
-	}
-
-	if (ddiBuffer != object->get_ddi())
-	{
-		object->set_ddi(ddiBuffer);
-	}
+	render_ddi_setting(object);
 
 	ImGui::BeginDisabled();
 	ImGui::InputInt("Object ID", &objectIDBuffer);
@@ -1234,20 +1240,7 @@ void DDOPGeneratorGUI::render_device_property_settings(std::shared_ptr<isobus::t
 		object->set_designator(designator);
 	}
 
-	ImGui::InputInt("DDI", &ddiBuffer);
-	if (ddiBuffer < 0)
-	{
-		ddiBuffer = 0;
-	}
-	else if (ddiBuffer > 0xFFFF)
-	{
-		ddiBuffer = 0xFFFF;
-	}
-
-	if (ddiBuffer != object->get_ddi())
-	{
-		object->set_ddi(ddiBuffer);
-	}
+	render_ddi_setting(object);
 
 	ImGui::InputInt("Value", &valueBuffer);
 	if (valueBuffer != object->get_value())

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -23,6 +23,9 @@
 #include <fstream>
 #include <sstream>
 
+constexpr std::uint16_t PROPRIETARY_DDI_RANGE_START = 57344;
+constexpr std::uint16_t PROPRIETARY_DDI_RANGE_END = 65534;
+
 void DDOPGeneratorGUI::start()
 {
 	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
@@ -728,9 +731,25 @@ void DDOPGeneratorGUI::render_ddi_setting(std::shared_ptr<T> object)
 		ddiBuffer = 0xFFFF;
 	}
 
-	if (ddiBuffer != object->get_ddi())
+	auto ddi = static_cast<std::uint16_t>(ddiBuffer);
+	const auto &entry = isobus::DataDictionary::get_entry(ddi);
+
+	if ((ddi >= PROPRIETARY_DDI_RANGE_START) && (ddi <= PROPRIETARY_DDI_RANGE_END))
 	{
-		object->set_ddi(ddiBuffer);
+		ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Proprietary DDI");
+	}
+	else if (entry.ddi == ddi)
+	{
+		ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "%s", entry.name.c_str());
+	}
+	else
+	{
+		ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "Not in ISO 11783-11");
+	}
+
+	if (ddi != object->get_ddi())
+	{
+		object->set_ddi(ddi);
 	}
 }
 


### PR DESCRIPTION
Whenever I am changing DDI field, it just shows a number right now. You have to go look it up the real name which is a bummer. This PR shows the name next to it, updates as you type.

Green = known DDI, name shown.
Yellow = proprietary range (57344–65534)
Red = not a real DDI.