### PR TITLE
Report every DDOP error and warning on Check for Errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Configure
         run: cmake -S . -B build -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCAN_DRIVER=None -DCMAKE_BUILD_TYPE=Release
       - name: Compile tests
-        run: cmake --build build --target example_pool_test
+        run: cmake --build build --target example_pool_test ddop_validator_test
       - name: Run tests
         run: ctest --test-dir build --output-on-failure
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(
   AgIsoDDOPGenerator
   PRIVATE src/main.cpp
           src/gui.cpp
+          src/ddop_validator.cpp
           submodules/imgui/imgui.cpp
           submodules/imgui/imgui_demo.cpp
           submodules/imgui/imgui_draw.cpp

--- a/include/ddop_validator.hpp
+++ b/include/ddop_validator.hpp
@@ -1,0 +1,42 @@
+//================================================================================================
+/// @file ddop_validator.hpp
+///
+/// @brief Defines the ISO 11783-10 conformance checks that "Check for Errors" runs on a DDOP
+/// @author Sujan Dumaru
+///
+/// @copyright 2026 The Open-Agriculture developers
+//================================================================================================
+#pragma once
+
+#include "isobus/isobus/isobus_device_descriptor_object_pool.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/// @brief The first DDI ISO 11783-11 leaves to manufacturers, which the dictionary does not define
+constexpr std::uint16_t PROPRIETARY_DDI_RANGE_START = 57344;
+
+/// @brief The last manufacturer-assignable DDI. 65535 is reserved.
+constexpr std::uint16_t PROPRIETARY_DDI_RANGE_END = 65534;
+
+/// @brief One problem found in a device descriptor object pool
+struct DDOPValidationFinding
+{
+	/// @brief How badly the problem breaks the pool
+	enum class Severity
+	{
+		Error, ///< The pool cannot be serialized at all
+		Warning ///< The pool serializes, but a TC may reject it or read it wrongly
+	};
+
+	Severity severity; ///< Whether serialization fails, or only acceptance by a TC is at risk
+	std::string message; ///< What is wrong, naming the objects involved
+};
+
+/// @brief Checks a pool against the ISO 11783-10 rules a task controller applies to a DDOP
+/// @details The stack's own serialization stops at the first broken reference, so the conditions
+/// that make it fail are re-derived here in order to report all of them in one pass.
+/// @param[in,out] pool The object pool to check. It is serialized, but never modified.
+/// @returns Every finding, errors first
+std::vector<DDOPValidationFinding> validate_ddop(isobus::DeviceDescriptorObjectPool &pool);

--- a/include/gui.hpp
+++ b/include/gui.hpp
@@ -9,6 +9,7 @@
 #ifndef GUI_HPP
 #define GUI_HPP
 
+#include "ddop_validator.hpp"
 #include "isobus/isobus/isobus_device_descriptor_object_pool.hpp"
 #include "isobus/isobus/isobus_language_command_interface.hpp"
 
@@ -27,6 +28,7 @@ private:
 	static constexpr std::size_t FILE_PATH_BUFFER_MAX_LENGTH = 1024;
 
 	bool render_menu_bar();
+	void render_validation_results();
 	void render_open_file_menu();
 	void parseElementChildrenOfElement(std::uint16_t objectID);
 	void parseChildren(std::shared_ptr<isobus::task_controller_object::DeviceElementObject> element);
@@ -78,6 +80,7 @@ private:
 	char extendedStructureLabelBuffer[129] = { 0 };
 	char hexIsoNameBuffer[17] = { 0 };
 	char languageCodeBuffer[3] = { 0 };
+	std::vector<DDOPValidationFinding> validationFindings;
 	std::string lastFileName;
 	int elementNumberBuffer = 0;
 	int parentObjectBuffer = 0;

--- a/src/ddop_validator.cpp
+++ b/src/ddop_validator.cpp
@@ -1,0 +1,599 @@
+//================================================================================================
+/// @file ddop_validator.cpp
+///
+/// @brief Implements the ISO 11783-10 conformance checks that "Check for Errors" runs on a DDOP
+/// @author Sujan Dumaru
+///
+/// @copyright 2026 The Open-Agriculture developers
+//================================================================================================
+#include "ddop_validator.hpp"
+
+#include "isobus/isobus/isobus_data_dictionary.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+
+using Object = isobus::task_controller_object::Object;
+using ObjectTypes = isobus::task_controller_object::ObjectTypes;
+using DeviceObject = isobus::task_controller_object::DeviceObject;
+using DeviceElementObject = isobus::task_controller_object::DeviceElementObject;
+using DeviceProcessDataObject = isobus::task_controller_object::DeviceProcessDataObject;
+using DevicePropertyObject = isobus::task_controller_object::DevicePropertyObject;
+using DeviceValuePresentationObject = isobus::task_controller_object::DeviceValuePresentationObject;
+using Severity = DDOPValidationFinding::Severity;
+
+constexpr std::uint16_t NULL_OBJECT_ID = 0xFFFF;
+
+/// @brief The first TC version that accepts a 128 byte designator and an extended structure label
+constexpr std::uint8_t FIRST_VERSION_4_ONLY_FEATURE_LEVEL = 4;
+
+/// @brief A process data message carries the element number in 12 bits, so nothing above this is addressable
+constexpr std::uint16_t MAX_ADDRESSABLE_ELEMENT_NUMBER = 4095;
+
+/// @brief The length of a designator, serial number or software version is stored in a single byte
+constexpr std::size_t MAX_LENGTH_PREFIXED_STRING_LENGTH = 255;
+
+/// @brief ISO 11783-10 defines bits 1 to 3 of the DPD properties bitfield. The rest are reserved.
+constexpr std::uint8_t RESERVED_PROPERTIES_BITS = 0xF8;
+
+/// @brief ISO 11783-10 defines bits 1 to 5 of the DPD trigger methods bitfield. The rest are reserved.
+constexpr std::uint8_t RESERVED_TRIGGER_METHOD_BITS = 0xE0;
+
+constexpr std::uint8_t MAX_NUMBER_OF_DECIMALS = 7;
+constexpr std::size_t MAX_LABELLED_DESIGNATOR_LENGTH = 32;
+
+/// @brief 32 four-byte characters is where the version 4 designator's 128 byte ceiling comes from
+constexpr std::size_t MAX_DESIGNATOR_CHARACTERS = 32;
+
+/// @brief The DDI a TC requests to learn which process data belong to the default set
+constexpr std::uint16_t REQUEST_DEFAULT_PROCESS_DATA_DDI = 0xDFFF;
+
+/// @brief Every trigger method, which is what the request default process data object has to offer
+constexpr std::uint8_t ALL_TRIGGER_METHODS = 0x1F;
+
+/// @brief Collects every object of one type, since each check below cares about one or two of them
+template<typename T>
+static std::vector<std::shared_ptr<T>> objects_of_type(isobus::DeviceDescriptorObjectPool &pool)
+{
+	std::vector<std::shared_ptr<T>> retVal;
+
+	for (std::uint16_t i = 0; i < pool.size(); i++)
+	{
+		auto object = std::dynamic_pointer_cast<T>(pool.get_object_by_index(i));
+
+		if (nullptr != object)
+		{
+			retVal.push_back(object);
+		}
+	}
+	return retVal;
+}
+
+/// @brief Joins object IDs the way a finding lists them
+static std::string join_object_ids(const std::vector<std::uint16_t> &objectIDs)
+{
+	std::string retVal;
+
+	for (const auto &objectID : objectIDs)
+	{
+		retVal += (retVal.empty() ? "" : ", ") + std::to_string(objectID);
+	}
+	return retVal;
+}
+
+/// @brief Counts the UTF-8 characters in a string, since a version 4 designator is limited by characters and not by bytes
+static std::size_t utf8_length(const std::string &value)
+{
+	std::size_t retVal = 0;
+
+	for (const auto &character : value)
+	{
+		// A continuation byte carries the top bits 10, so every other byte starts a new character
+		if (0x80 != (0xC0 & static_cast<std::uint8_t>(character)))
+		{
+			retVal++;
+		}
+	}
+	return retVal;
+}
+
+/// @brief Names an object the way the pool's own table IDs do, so a finding can be traced to it
+static std::string object_label(const std::shared_ptr<Object> &object)
+{
+	std::string retVal = object->get_table_id() + " " + std::to_string(object->get_object_id());
+	std::string designator = object->get_designator();
+
+	if (designator.size() > MAX_LABELLED_DESIGNATOR_LENGTH)
+	{
+		designator.resize(MAX_LABELLED_DESIGNATOR_LENGTH);
+
+		// Cutting a UTF-8 sequence in half would render as a replacement glyph, so drop the partial character
+		while (!designator.empty() && (0x80 == (0xC0 & static_cast<std::uint8_t>(designator.back()))))
+		{
+			designator.pop_back();
+		}
+		designator += "...";
+	}
+
+	if (!designator.empty())
+	{
+		retVal += " (\"" + designator + "\")";
+	}
+	return retVal;
+}
+
+/// @brief Reports every device element whose parent, or whose child references, cannot be resolved
+static void check_device_element_references(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	for (const auto &element : objects_of_type<DeviceElementObject>(pool))
+	{
+		if (NULL_OBJECT_ID == element->get_parent_object())
+		{
+			findings.push_back({ Severity::Error, object_label(element) + " has no parent object. Every device element must name the device object or another device element as its parent." });
+		}
+		else
+		{
+			auto parent = pool.get_object_by_id(element->get_parent_object());
+
+			if (nullptr == parent)
+			{
+				findings.push_back({ Severity::Error, object_label(element) + " names object " + std::to_string(element->get_parent_object()) + " as its parent, but no object in the pool has that ID." });
+			}
+			else if ((ObjectTypes::Device != parent->get_object_type()) &&
+			         (ObjectTypes::DeviceElement != parent->get_object_type()))
+			{
+				findings.push_back({ Severity::Error, object_label(element) + " names " + object_label(parent) + " as its parent. Only the device object or another device element may be a parent." });
+			}
+		}
+
+		for (std::uint16_t child = 0; child < element->get_number_child_objects(); child++)
+		{
+			auto childObject = pool.get_object_by_id(element->get_child_object_id(child));
+
+			if (nullptr == childObject)
+			{
+				findings.push_back({ Severity::Error, object_label(element) + " references child object " + std::to_string(element->get_child_object_id(child)) + ", but no object in the pool has that ID." });
+			}
+			else if ((ObjectTypes::DeviceProcessData != childObject->get_object_type()) &&
+			         (ObjectTypes::DeviceProperty != childObject->get_object_type()))
+			{
+				findings.push_back({ Severity::Error, object_label(element) + " has " + object_label(childObject) + " as a child. A device element may only have device process data and device property children." });
+			}
+		}
+	}
+}
+
+/// @brief Reports a process data or property object whose value presentation reference is broken
+static void check_value_presentation_reference(isobus::DeviceDescriptorObjectPool &pool, const std::shared_ptr<Object> &object, std::uint16_t presentationObjectID, std::vector<DDOPValidationFinding> &findings)
+{
+	if (NULL_OBJECT_ID == presentationObjectID)
+	{
+		return;
+	}
+	auto presentation = pool.get_object_by_id(presentationObjectID);
+
+	if (nullptr == presentation)
+	{
+		findings.push_back({ Severity::Error, object_label(object) + " names object " + std::to_string(presentationObjectID) + " as its value presentation, but no object in the pool has that ID." });
+	}
+	else if (ObjectTypes::DeviceValuePresentation != presentation->get_object_type())
+	{
+		findings.push_back({ Severity::Error, object_label(object) + " names " + object_label(presentation) + " as its value presentation. Only a device value presentation object may be one." });
+	}
+}
+
+/// @brief Reports every broken value presentation reference in the pool
+static void check_presentation_references(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	for (const auto &processData : objects_of_type<DeviceProcessDataObject>(pool))
+	{
+		check_value_presentation_reference(pool, processData, processData->get_device_value_presentation_object_id(), findings);
+	}
+
+	for (const auto &property : objects_of_type<DevicePropertyObject>(pool))
+	{
+		check_value_presentation_reference(pool, property, property->get_device_value_presentation_object_id(), findings);
+	}
+}
+
+/// @brief Reports the device object's own problems, and the absence of one
+static void check_device_object(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	auto devices = objects_of_type<DeviceObject>(pool);
+
+	if (devices.empty())
+	{
+		findings.push_back({ Severity::Warning, "The pool has no device object. ISO 11783-10 requires exactly one, and a TC will reject a pool without it." });
+		return;
+	}
+	else if (1 < devices.size())
+	{
+		findings.push_back({ Severity::Warning, "The pool has " + std::to_string(devices.size()) + " device objects. ISO 11783-10 requires exactly one." });
+	}
+	const auto &device = devices.back();
+
+	if (device->get_structure_label().empty())
+	{
+		findings.push_back({ Severity::Warning, "The device object's structure label is empty, so it is sent as seven spaces. A TC keys its cached copy of the pool on this label, and every pool that leaves it empty presents the same one, so the TC cannot tell one version of the pool from another." });
+	}
+
+	if (0 == device->get_iso_name())
+	{
+		findings.push_back({ Severity::Warning, "The device object's ISO NAME is 0. A TC compares this against the NAME of the client that uploads the pool, and rejects the pool when they differ." });
+	}
+
+	if (0xFF != device->get_localization_label()[6])
+	{
+		findings.push_back({ Severity::Warning, "Byte 7 of the device object's localization label is reserved and must be 0xFF." });
+	}
+
+	if (!device->get_extended_structure_label().empty() &&
+	    (pool.get_task_controller_compatibility_level() < FIRST_VERSION_4_ONLY_FEATURE_LEVEL))
+	{
+		findings.push_back({ Severity::Warning, "The device object carries an extended structure label, which only a version 4 TC reads. This pool is set to version " + std::to_string(pool.get_task_controller_compatibility_level()) + "." });
+	}
+
+	if (device->get_extended_structure_label().size() > DeviceObject::MAX_EXTENDED_STRUCTURE_LABEL_LENGTH)
+	{
+		findings.push_back({ Severity::Warning, "The device object's extended structure label is " + std::to_string(device->get_extended_structure_label().size()) + " bytes, above the ISO 11783-10 limit of " + std::to_string(DeviceObject::MAX_EXTENDED_STRUCTURE_LABEL_LENGTH) + "." });
+	}
+
+	if (device->get_structure_label().size() > DeviceObject::MAX_STRUCTURE_AND_LOCALIZATION_LABEL_LENGTH)
+	{
+		findings.push_back({ Severity::Warning, "The device object's structure label is " + std::to_string(device->get_structure_label().size()) + " bytes, above the ISO 11783-10 limit of " + std::to_string(DeviceObject::MAX_STRUCTURE_AND_LOCALIZATION_LABEL_LENGTH) + ". The stack will truncate it." });
+	}
+}
+
+/// @brief Reports one length-prefixed string that is longer than the TC version allows
+static void check_string_length(const std::string &description, const std::string &value, std::uint8_t taskControllerVersion, std::vector<DDOPValidationFinding> &findings)
+{
+	if (value.size() > MAX_LENGTH_PREFIXED_STRING_LENGTH)
+	{
+		findings.push_back({ Severity::Warning, description + " is " + std::to_string(value.size()) + " bytes. Its length is stored in a single byte, so a TC will read the wrong length and every object after it in the pool becomes unreadable." });
+	}
+	else if (taskControllerVersion < FIRST_VERSION_4_ONLY_FEATURE_LEVEL)
+	{
+		if (value.size() > Object::MAX_DESIGNATOR_LEGACY_LENGTH)
+		{
+			findings.push_back({ Severity::Warning, description + " is " + std::to_string(value.size()) + " bytes, above the " + std::to_string(Object::MAX_DESIGNATOR_LEGACY_LENGTH) + " byte limit for a version " + std::to_string(taskControllerVersion) + " pool." });
+		}
+	}
+	else if (value.size() > Object::MAX_DESIGNATOR_LENGTH)
+	{
+		findings.push_back({ Severity::Warning, description + " is " + std::to_string(value.size()) + " bytes, above the " + std::to_string(Object::MAX_DESIGNATOR_LENGTH) + " byte limit for a version 4 pool." });
+	}
+	else if (utf8_length(value) > MAX_DESIGNATOR_CHARACTERS)
+	{
+		findings.push_back({ Severity::Warning, description + " is " + std::to_string(utf8_length(value)) + " UTF-8 characters, above the ISO 11783-10 limit of " + std::to_string(MAX_DESIGNATOR_CHARACTERS) + " for a version 4 pool. The 128 byte limit is what 32 four-byte characters take up, not a longer allowance." });
+	}
+}
+
+/// @brief Reports every designator, serial number and software version that is too long
+static void check_string_lengths(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	const std::uint8_t version = pool.get_task_controller_compatibility_level();
+
+	for (const auto &object : objects_of_type<Object>(pool))
+	{
+		check_string_length("The designator of " + object_label(object), object->get_designator(), version, findings);
+	}
+
+	for (const auto &device : objects_of_type<DeviceObject>(pool))
+	{
+		check_string_length("The device object's serial number", device->get_serial_number(), version, findings);
+		check_string_length("The device object's software version", device->get_software_version(), version, findings);
+	}
+}
+
+/// @brief Reports element numbers a TC cannot address, or cannot tell apart
+static void check_element_numbers(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	std::map<std::uint16_t, std::vector<std::uint16_t>> objectIDsByElementNumber;
+
+	for (const auto &element : objects_of_type<DeviceElementObject>(pool))
+	{
+		objectIDsByElementNumber[element->get_element_number()].push_back(element->get_object_id());
+
+		if (element->get_element_number() > MAX_ADDRESSABLE_ELEMENT_NUMBER)
+		{
+			findings.push_back({ Severity::Warning, object_label(element) + " uses element number " + std::to_string(element->get_element_number()) + ". A process data message carries the element number in 12 bits, so a TC cannot address anything above " + std::to_string(MAX_ADDRESSABLE_ELEMENT_NUMBER) + "." });
+		}
+	}
+
+	for (const auto &elementNumberAndObjectIDs : objectIDsByElementNumber)
+	{
+		if (1 < elementNumberAndObjectIDs.second.size())
+		{
+			findings.push_back({ Severity::Warning, "Element number " + std::to_string(elementNumberAndObjectIDs.first) + " is used by device elements " + join_object_ids(elementNumberAndObjectIDs.second) + ". A TC addresses process data by element number, so each device element needs its own." });
+		}
+	}
+}
+
+/// @brief Reports whether following an element's parents revisits an element instead of terminating
+static bool has_parent_cycle(isobus::DeviceDescriptorObjectPool &pool, std::shared_ptr<DeviceElementObject> element)
+{
+	std::set<std::uint16_t> visited;
+
+	while (visited.insert(element->get_object_id()).second)
+	{
+		auto parent = std::dynamic_pointer_cast<DeviceElementObject>(pool.get_object_by_id(element->get_parent_object()));
+
+		if (nullptr == parent)
+		{
+			return false;
+		}
+		element = parent;
+	}
+	return true;
+}
+
+/// @brief Reports a device element tree that is not the single rooted tree ISO 11783-10 describes
+static void check_element_hierarchy(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	std::vector<std::uint16_t> rootElements;
+	std::vector<std::uint16_t> deviceTypeElements;
+
+	for (const auto &element : objects_of_type<DeviceElementObject>(pool))
+	{
+		auto parent = pool.get_object_by_id(element->get_parent_object());
+
+		if ((nullptr != parent) && (ObjectTypes::Device == parent->get_object_type()))
+		{
+			rootElements.push_back(element->get_object_id());
+		}
+
+		if (DeviceElementObject::Type::Device == element->get_type())
+		{
+			deviceTypeElements.push_back(element->get_object_id());
+
+			if (0 != element->get_element_number())
+			{
+				findings.push_back({ Severity::Warning, object_label(element) + " has the type Device but element number " + std::to_string(element->get_element_number()) + ". A TC addresses the device itself as element 0, so it will not find this element there." });
+			}
+		}
+
+		if (has_parent_cycle(pool, element))
+		{
+			findings.push_back({ Severity::Warning, object_label(element) + " sits in a cycle of parent references, so following its parents never reaches the device object. A TC cannot place it in the element tree, and walking the tree may not terminate." });
+		}
+	}
+
+	if (deviceTypeElements.empty())
+	{
+		findings.push_back({ Severity::Warning, "No device element has the type Device. ISO 11783-10 requires exactly one, and it is the element a TC treats as the whole device." });
+	}
+	else if (1 < deviceTypeElements.size())
+	{
+		findings.push_back({ Severity::Warning, "Device elements " + join_object_ids(deviceTypeElements) + " all have the type Device. ISO 11783-10 requires exactly one." });
+	}
+
+	if (1 < rootElements.size())
+	{
+		findings.push_back({ Severity::Warning, "Device elements " + join_object_ids(rootElements) + " all name the device object as their parent. The element tree should have a single root." });
+	}
+}
+
+/// @brief Reports a DDI a TC has no definition for
+static void check_ddi(const std::shared_ptr<Object> &object, std::uint16_t ddi, std::vector<DDOPValidationFinding> &findings)
+{
+	if (ddi > PROPRIETARY_DDI_RANGE_END)
+	{
+		findings.push_back({ Severity::Warning, object_label(object) + " uses DDI " + std::to_string(ddi) + ", which ISO 11783-11 reserves." });
+	}
+	else if ((ddi < PROPRIETARY_DDI_RANGE_START) &&
+	         (isobus::DataDictionary::get_entry(ddi).ddi != ddi))
+	{
+		findings.push_back({ Severity::Warning, object_label(object) + " uses DDI " + std::to_string(ddi) + ", which is not in this app's bundled copy of the ISO 11783-11 data dictionary. Either it is not a defined DDI, or the bundled copy predates it." });
+	}
+}
+
+/// @brief Reports process data and property objects a TC cannot use as declared
+static void check_process_data(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	for (const auto &property : objects_of_type<DevicePropertyObject>(pool))
+	{
+		check_ddi(property, property->get_ddi(), findings);
+	}
+
+	for (const auto &processData : objects_of_type<DeviceProcessDataObject>(pool))
+	{
+		const std::uint8_t properties = processData->get_properties_bitfield();
+		const std::uint8_t triggers = processData->get_trigger_methods_bitfield();
+
+		check_ddi(processData, processData->get_ddi(), findings);
+
+		if (0 != (properties & RESERVED_PROPERTIES_BITS))
+		{
+			findings.push_back({ Severity::Warning, object_label(processData) + " sets reserved bits in its properties bitfield. ISO 11783-10 defines only the first three." });
+		}
+
+		if ((0 != (properties & static_cast<std::uint8_t>(DeviceProcessDataObject::PropertiesBit::ControlSource))) &&
+		    (pool.get_task_controller_compatibility_level() < FIRST_VERSION_4_ONLY_FEATURE_LEVEL))
+		{
+			findings.push_back({ Severity::Warning, object_label(processData) + " is marked as a control source, which only a version 4 TC understands. This pool is set to version " + std::to_string(pool.get_task_controller_compatibility_level()) + "." });
+		}
+
+		if ((0 != (properties & static_cast<std::uint8_t>(DeviceProcessDataObject::PropertiesBit::ControlSource))) &&
+		    (0 != (properties & static_cast<std::uint8_t>(DeviceProcessDataObject::PropertiesBit::Settable))))
+		{
+			findings.push_back({ Severity::Warning, object_label(processData) + " is marked both settable and a control source. ISO 11783-10 makes those two mutually exclusive." });
+		}
+
+		if (0 != (triggers & RESERVED_TRIGGER_METHOD_BITS))
+		{
+			findings.push_back({ Severity::Warning, object_label(processData) + " sets reserved bits in its trigger methods bitfield. ISO 11783-10 defines only the first five." });
+		}
+	}
+}
+
+/// @brief Reports a default set a TC has no way to ask for
+///
+/// A TC learns which process data are in the default set by requesting DDI 0xDFFF, so a pool that marks
+/// members without offering that object never has its default set read. Every pool in the vendor corpus
+/// that marks a member carries the object on the device element numbered 0, offering all trigger methods.
+static void check_default_process_data(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	std::shared_ptr<Object> requestObject;
+	bool markedAMember = false;
+
+	for (const auto &processData : objects_of_type<DeviceProcessDataObject>(pool))
+	{
+		if (0 != (processData->get_properties_bitfield() & static_cast<std::uint8_t>(DeviceProcessDataObject::PropertiesBit::MemberOfDefaultSet)))
+		{
+			markedAMember = true;
+		}
+
+		if (REQUEST_DEFAULT_PROCESS_DATA_DDI == processData->get_ddi())
+		{
+			requestObject = processData;
+
+			if (ALL_TRIGGER_METHODS != processData->get_trigger_methods_bitfield())
+			{
+				findings.push_back({ Severity::Warning, object_label(processData) + " is the request default process data object, which has to offer every trigger method. A TC may not accept the pool when it offers fewer." });
+			}
+		}
+	}
+
+	if (!markedAMember)
+	{
+		return;
+	}
+
+	if (nullptr == requestObject)
+	{
+		findings.push_back({ Severity::Warning, "Process data objects are marked as members of the default set, but the pool has no object for DDI 57343 (0xDFFF), which is what a TC requests to read that set. Nothing will ever ask for these values." });
+		return;
+	}
+
+	for (const auto &element : objects_of_type<DeviceElementObject>(pool))
+	{
+		for (std::uint16_t child = 0; child < element->get_number_child_objects(); child++)
+		{
+			if (requestObject->get_object_id() == element->get_child_object_id(child))
+			{
+				if (0 != element->get_element_number())
+				{
+					findings.push_back({ Severity::Warning, object_label(requestObject) + " is the request default process data object, but it hangs off element number " + std::to_string(element->get_element_number()) + ". A TC asks element 0 for it." });
+				}
+				return;
+			}
+		}
+	}
+	findings.push_back({ Severity::Warning, object_label(requestObject) + " is the request default process data object, but it is not a child of any device element, so a TC cannot request it." });
+}
+
+/// @brief Reports value presentations that cannot present a value
+static void check_value_presentations(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	for (const auto &presentation : objects_of_type<DeviceValuePresentationObject>(pool))
+	{
+		if (!std::isfinite(presentation->get_scale()))
+		{
+			findings.push_back({ Severity::Warning, object_label(presentation) + " has a scale that is not a finite number. A TC cannot multiply a raw value by it, and it does not survive being written to the pool as a float." });
+		}
+		else if (presentation->get_scale() <= 0.0f)
+		{
+			findings.push_back({ Severity::Warning, object_label(presentation) + " has a scale of " + std::to_string(presentation->get_scale()) + ". A TC multiplies every raw value by the scale, so nothing but the offset would ever be displayed." });
+		}
+
+		if (presentation->get_number_of_decimals() > MAX_NUMBER_OF_DECIMALS)
+		{
+			findings.push_back({ Severity::Warning, object_label(presentation) + " asks for " + std::to_string(presentation->get_number_of_decimals()) + " decimals. ISO 11783-10 allows at most " + std::to_string(MAX_NUMBER_OF_DECIMALS) + "." });
+		}
+	}
+}
+
+/// @brief Reports objects nothing points at, which a TC can never reach through the pool
+static void check_unreferenced_objects(isobus::DeviceDescriptorObjectPool &pool, std::vector<DDOPValidationFinding> &findings)
+{
+	std::set<std::uint16_t> referencedObjectIDs;
+
+	for (const auto &element : objects_of_type<DeviceElementObject>(pool))
+	{
+		for (std::uint16_t child = 0; child < element->get_number_child_objects(); child++)
+		{
+			referencedObjectIDs.insert(element->get_child_object_id(child));
+		}
+	}
+
+	for (const auto &object : objects_of_type<Object>(pool))
+	{
+		if ((0 == referencedObjectIDs.count(object->get_object_id())) &&
+		    ((ObjectTypes::DeviceProcessData == object->get_object_type()) ||
+		     (ObjectTypes::DeviceProperty == object->get_object_type())))
+		{
+			findings.push_back({ Severity::Warning, object_label(object) + " is not a child of any device element, so a TC can never address it." });
+		}
+	}
+}
+
+/// @brief Serializes the pool and reads it back with the ISOBUS stack this app is built on
+///
+/// This is a read-back check against one implementation, not evidence of what any TC accepts.
+static void check_stack_read_back(isobus::DeviceDescriptorObjectPool &pool, bool foundAnError, std::vector<DDOPValidationFinding> &findings)
+{
+	std::vector<std::uint8_t> binaryPool;
+
+	if (!pool.generate_binary_object_pool(binaryPool))
+	{
+		if (!foundAnError)
+		{
+			findings.push_back({ Severity::Error, "The pool could not be serialized, for a reason none of these checks covers. The log below is what the ISOBUS stack reported." });
+		}
+		return;
+	}
+	isobus::DeviceDescriptorObjectPool readBack(pool.get_task_controller_compatibility_level());
+
+	if (!readBack.deserialize_binary_object_pool(binaryPool, isobus::NAME(0)))
+	{
+		findings.push_back({ Severity::Warning, "The serialized pool cannot be read back by the ISOBUS stack this app is built on. That is not proof a TC will reject it, but nothing here can say what a TC would make of it." });
+		return;
+	}
+
+	if (readBack.size() != pool.size())
+	{
+		findings.push_back({ Severity::Warning, "Reading the serialized pool back yields " + std::to_string(readBack.size()) + " objects instead of " + std::to_string(pool.size()) + ". A reader will not see the pool you built." });
+		return;
+	}
+	std::vector<std::uint8_t> reserializedPool;
+
+	// Comparing the bytes rather than the object count is what catches a field the reader drops or rewrites,
+	// such as the device object's ID, which the stack does not carry back out of the binary at all
+	if (!readBack.generate_binary_object_pool(reserializedPool))
+	{
+		findings.push_back({ Severity::Warning, "The pool serializes, but the result cannot be serialized again after being read back. A reader does not end up holding the pool you built." });
+	}
+	else if (reserializedPool != binaryPool)
+	{
+		findings.push_back({ Severity::Warning, "Reading the serialized pool back and writing it out again does not reproduce the same bytes, so at least one field does not survive the trip. A reader holds something other than the pool you built." });
+	}
+}
+
+std::vector<DDOPValidationFinding> validate_ddop(isobus::DeviceDescriptorObjectPool &pool)
+{
+	std::vector<DDOPValidationFinding> findings;
+
+	check_device_element_references(pool, findings);
+	check_presentation_references(pool, findings);
+
+	const bool foundAnError = !findings.empty();
+
+	check_device_object(pool, findings);
+	check_string_lengths(pool, findings);
+	check_element_numbers(pool, findings);
+	check_element_hierarchy(pool, findings);
+	check_process_data(pool, findings);
+	check_default_process_data(pool, findings);
+	check_value_presentations(pool, findings);
+	check_unreferenced_objects(pool, findings);
+	check_stack_read_back(pool, foundAnError, findings);
+
+	std::stable_partition(findings.begin(), findings.end(), [](const DDOPValidationFinding &finding) {
+		return Severity::Error == finding.severity;
+	});
+	return findings;
+}

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -495,14 +495,6 @@ void DDOPGeneratorGUI::render_validation_results()
 		}
 		ImGui::EndChild();
 	}
-
-	if (!logger.logHistory.empty() && ImGui::CollapsingHeader("What the ISOBUS stack logged"))
-	{
-		for (auto &logString : logger.logHistory)
-		{
-			ImGui::TextWrapped("%s", logString.logText.c_str());
-		}
-	}
 }
 
 void DDOPGeneratorGUI::render_open_file_menu()

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -10,6 +10,7 @@
 #include "L2DFileDialog.hpp"
 #include "SDL.h"
 #include "SDL_opengl.h"
+#include "ddop_validator.hpp"
 #include "imgui.h"
 #include "imgui_impl_opengl3.h"
 #include "imgui_impl_sdl2.h"
@@ -17,53 +18,12 @@
 #include "isobus/utility/iop_file_interface.hpp"
 #include "logsink.hpp"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
-#include <map>
 #include <sstream>
-
-constexpr std::uint16_t PROPRIETARY_DDI_RANGE_START = 57344;
-constexpr std::uint16_t PROPRIETARY_DDI_RANGE_END = 65534;
-
-/// @brief Logs a warning for each device element number used by more than one device element
-/// @param[in] objectPool The device descriptor object pool to scan
-static void warn_on_duplicate_device_element_numbers(isobus::DeviceDescriptorObjectPool &objectPool)
-{
-	std::map<std::uint16_t, std::vector<std::uint16_t>> objectIDsByElementNumber;
-	bool foundDuplicate = false;
-
-	for (std::uint16_t i = 0; i < objectPool.size(); ++i)
-	{
-		auto deviceElement = std::dynamic_pointer_cast<isobus::task_controller_object::DeviceElementObject>(objectPool.get_object_by_index(i));
-
-		if (nullptr != deviceElement)
-		{
-			objectIDsByElementNumber[deviceElement->get_element_number()].push_back(deviceElement->get_object_id());
-		}
-	}
-
-	for (const auto &elementNumberAndObjectIDs : objectIDsByElementNumber)
-	{
-		if (1 < elementNumberAndObjectIDs.second.size())
-		{
-			std::ostringstream objectIDs;
-
-			for (std::size_t i = 0; i < elementNumberAndObjectIDs.second.size(); ++i)
-			{
-				objectIDs << ((0 == i) ? "" : ", ") << elementNumberAndObjectIDs.second[i];
-			}
-			LOG_WARNING("[DDOP]: Device element number %u is used by more than one device element (object IDs %s).", elementNumberAndObjectIDs.first, objectIDs.str().c_str());
-			foundDuplicate = true;
-		}
-	}
-
-	if (foundDuplicate)
-	{
-		LOG_WARNING("[DDOP]: A TC addresses process data by element number, so each device element needs its own number.");
-	}
-}
 
 void DDOPGeneratorGUI::start()
 {
@@ -294,8 +254,7 @@ void DDOPGeneratorGUI::start()
 bool DDOPGeneratorGUI::render_menu_bar()
 {
 	bool retVal = false;
-	bool shouldShowErrors = false;
-	bool shouldShowNoErrors = false;
+	bool shouldShowValidationResults = false;
 	bool shouldShowNewDDOP = false;
 	bool shouldShowAbout = false;
 
@@ -380,23 +339,13 @@ bool DDOPGeneratorGUI::render_menu_bar()
 				ImGui::BeginDisabled();
 			}
 
-			if (true == ImGui::MenuItem("Check for Errors", "Serialize the DDOP and display detected errors"))
+			if (true == ImGui::MenuItem("Check for Errors", "Check the DDOP against the ISO 11783-10 rules a TC applies"))
 			{
 				if ((nullptr != currentObjectPool) && currentPoolValid)
 				{
-					std::vector<std::uint8_t> binaryDDOP;
 					logger.logHistory.clear();
-					auto serializationSuccess = currentObjectPool->generate_binary_object_pool(binaryDDOP);
-
-					if (serializationSuccess)
-					{
-						warn_on_duplicate_device_element_numbers(*currentObjectPool);
-						shouldShowNoErrors = true;
-					}
-					else
-					{
-						shouldShowErrors = true;
-					}
+					validationFindings = validate_ddop(*currentObjectPool);
+					shouldShowValidationResults = true;
 				}
 			}
 			else if (!currentPoolValid)
@@ -458,13 +407,9 @@ bool DDOPGeneratorGUI::render_menu_bar()
 		ImGui::EndMainMenuBar();
 	}
 
-	if (shouldShowNoErrors)
+	if (shouldShowValidationResults)
 	{
-		ImGui::OpenPopup("No Serialization Errors");
-	}
-	else if (shouldShowErrors)
-	{
-		ImGui::OpenPopup("Serialization Errors");
+		ImGui::OpenPopup("Check Results");
 	}
 	else if (shouldShowNewDDOP)
 	{
@@ -475,38 +420,9 @@ bool DDOPGeneratorGUI::render_menu_bar()
 		ImGui::OpenPopup("About");
 	}
 
-	if (ImGui::BeginPopupModal("No Serialization Errors", NULL, ImGuiWindowFlags_AlwaysAutoResize))
+	if (ImGui::BeginPopupModal("Check Results", NULL, ImGuiWindowFlags_AlwaysAutoResize))
 	{
-		ImGui::Text("No serialization errors detected.");
-		ImGui::Text("This does not mean the DDOP will be accepted by a TC");
-		ImGui::Text("it only confirms the structure of the DDOP is valid.");
-		if (!logger.logHistory.empty())
-		{
-			ImGui::Separator();
-			ImGui::Text("Warnings:");
-
-			for (auto &logString : logger.logHistory)
-			{
-				ImGui::Text("%s", logString.logText.c_str());
-			}
-		}
-
-		ImGui::SetItemDefaultFocus();
-		if (ImGui::Button("OK", ImVec2(120, 0)))
-		{
-			ImGui::CloseCurrentPopup();
-		}
-		ImGui::EndPopup();
-	}
-	if (ImGui::BeginPopupModal("Serialization Errors", NULL, ImGuiWindowFlags_AlwaysAutoResize))
-	{
-		ImGui::Text("Serialization errors detected.");
-		ImGui::Separator();
-
-		for (auto &logString : logger.logHistory)
-		{
-			ImGui::Text("%s", logString.logText.c_str());
-		}
+		render_validation_results();
 
 		ImGui::SetItemDefaultFocus();
 		if (ImGui::Button("OK", ImVec2(120, 0)))
@@ -547,6 +463,46 @@ bool DDOPGeneratorGUI::render_menu_bar()
 	}
 
 	return retVal;
+}
+
+void DDOPGeneratorGUI::render_validation_results()
+{
+	const std::size_t errorCount = static_cast<std::size_t>(std::count_if(validationFindings.begin(), validationFindings.end(), [](const DDOPValidationFinding &finding) {
+		return DDOPValidationFinding::Severity::Error == finding.severity;
+	}));
+
+	if (validationFindings.empty())
+	{
+		ImGui::Text("No problems found.");
+		ImGui::Text("The DDOP serializes, reads back as the same pool, and passes every ISO 11783-10 check this app makes.");
+	}
+	else
+	{
+		ImGui::Text("%zu error(s) and %zu warning(s).", errorCount, validationFindings.size() - errorCount);
+		ImGui::Text("An error stops the DDOP from being generated at all.");
+		ImGui::Text("A warning means it is generated, but a TC may reject it or read it as something else.");
+		ImGui::Separator();
+
+		ImGui::BeginChild("Findings", ImVec2(760.0f, 320.0f), true);
+
+		for (const auto &finding : validationFindings)
+		{
+			const bool isError = (DDOPValidationFinding::Severity::Error == finding.severity);
+
+			ImGui::PushStyleColor(ImGuiCol_Text, isError ? ImVec4(1.0f, 0.4f, 0.4f, 1.0f) : ImVec4(1.0f, 1.0f, 0.0f, 1.0f));
+			ImGui::TextWrapped("%s: %s", isError ? "Error" : "Warning", finding.message.c_str());
+			ImGui::PopStyleColor();
+		}
+		ImGui::EndChild();
+	}
+
+	if (!logger.logHistory.empty() && ImGui::CollapsingHeader("What the ISOBUS stack logged"))
+	{
+		for (auto &logString : logger.logHistory)
+		{
+			ImGui::TextWrapped("%s", logString.logText.c_str());
+		}
+	}
 }
 
 void DDOPGeneratorGUI::render_open_file_menu()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,3 +5,12 @@ target_link_libraries(example_pool_test PRIVATE isobus::Isobus isobus::Utility)
 
 add_test(NAME example_pool_round_trip
          COMMAND example_pool_test "${PROJECT_SOURCE_DIR}/EXAMPLE.iop")
+
+add_executable(ddop_validator_test ddop_validator_test.cpp
+               "${PROJECT_SOURCE_DIR}/src/ddop_validator.cpp")
+set_property(TARGET ddop_validator_test PROPERTY CXX_STANDARD 17)
+set_property(TARGET ddop_validator_test PROPERTY CXX_STANDARD_REQUIRED true)
+target_include_directories(ddop_validator_test PRIVATE "${PROJECT_SOURCE_DIR}/include")
+target_link_libraries(ddop_validator_test PRIVATE isobus::Isobus isobus::Utility)
+
+add_test(NAME ddop_validator_rules COMMAND ddop_validator_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,11 +6,14 @@ target_link_libraries(example_pool_test PRIVATE isobus::Isobus isobus::Utility)
 add_test(NAME example_pool_round_trip
          COMMAND example_pool_test "${PROJECT_SOURCE_DIR}/EXAMPLE.iop")
 
-add_executable(ddop_validator_test ddop_validator_test.cpp
-               "${PROJECT_SOURCE_DIR}/src/ddop_validator.cpp")
+add_executable(
+  ddop_validator_test ddop_validator_test.cpp
+                      "${PROJECT_SOURCE_DIR}/src/ddop_validator.cpp")
 set_property(TARGET ddop_validator_test PROPERTY CXX_STANDARD 17)
 set_property(TARGET ddop_validator_test PROPERTY CXX_STANDARD_REQUIRED true)
-target_include_directories(ddop_validator_test PRIVATE "${PROJECT_SOURCE_DIR}/include")
-target_link_libraries(ddop_validator_test PRIVATE isobus::Isobus isobus::Utility)
+target_include_directories(ddop_validator_test
+                           PRIVATE "${PROJECT_SOURCE_DIR}/include")
+target_link_libraries(ddop_validator_test PRIVATE isobus::Isobus
+                                                  isobus::Utility)
 
 add_test(NAME ddop_validator_rules COMMAND ddop_validator_test)

--- a/test/ddop_validator_test.cpp
+++ b/test/ddop_validator_test.cpp
@@ -1,0 +1,306 @@
+//================================================================================================
+/// @file ddop_validator_test.cpp
+///
+/// @brief Checks every rule validate_ddop() applies, against pools built to break exactly one rule
+/// @author Sujan Dumaru
+///
+/// @copyright 2026 The Open-Agriculture developers
+//================================================================================================
+
+#include "ddop_validator.hpp"
+#include "isobus/utility/iop_file_interface.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace isobus::task_controller_object;
+
+// Not assert(): the repository builds Release by default, which would define NDEBUG and delete both
+// the check and the pool it is being run on
+#define CHECK(condition) check_condition((condition), #condition, __LINE__)
+
+static void check_condition(bool result, const char *text, int line)
+{
+	if (!result)
+	{
+		std::fprintf(stderr, "FAIL line %d: %s\n", line, text);
+		std::exit(1);
+	}
+}
+
+static std::size_t count(const std::vector<DDOPValidationFinding> &findings, DDOPValidationFinding::Severity severity)
+{
+	return std::count_if(findings.begin(), findings.end(), [severity](const DDOPValidationFinding &finding) {
+		return severity == finding.severity;
+	});
+}
+
+// The conformant pool every rule check breaks one thing in.
+static std::unique_ptr<isobus::DeviceDescriptorObjectPool> make_clean_pool(std::uint8_t version)
+{
+	std::unique_ptr<isobus::DeviceDescriptorObjectPool> pool(new isobus::DeviceDescriptorObjectPool(version));
+	std::array<std::uint8_t, 7> localization = { 'e', 'n', 0x50, 0x00, 0x00, 0x00, 0xFF };
+
+	CHECK(pool->add_device("Sprayer", "1.0", "SN1", "STRUCT1", localization, {}, 0xA000000000000000));
+	CHECK(pool->add_device_element("Root", 0, 0, DeviceElementObject::Type::Device, 1));
+	CHECK(pool->add_device_value_presentation("mm", 0, 1.0f, 0, 2));
+	CHECK(pool->add_device_process_data("Width", 70, 2, 0x01, 0x01, 3));
+
+	// Marking a member of the default set obliges the pool to carry the object a TC requests that set with
+	CHECK(pool->add_device_process_data("Request Default Process Data", 0xDFFF, 0xFFFF, 0x00, 0x1F, 4));
+	auto root = std::static_pointer_cast<DeviceElementObject>(pool->get_object_by_id(1));
+	root->add_reference_to_child_object(3);
+	root->add_reference_to_child_object(4);
+	return pool;
+}
+
+// How many findings mention the given text, which is how each rule is identified.
+static std::size_t times_fired(const std::vector<DDOPValidationFinding> &findings, const std::string &text)
+{
+	return std::count_if(findings.begin(), findings.end(), [&text](const DDOPValidationFinding &finding) {
+		return std::string::npos != finding.message.find(text);
+	});
+}
+
+static bool fires(const std::vector<DDOPValidationFinding> &findings, const std::string &text)
+{
+	return 0 != times_fired(findings, text);
+}
+
+// Naming every rule is what makes this coverage rather than a count that any twenty findings satisfy.
+static void check_every_rule_fires(const std::vector<DDOPValidationFinding> &findings, std::initializer_list<const char *> rules)
+{
+	for (const auto &rule : rules)
+	{
+		if (!fires(findings, rule))
+		{
+			printf("  MISSING RULE: %s\n", rule);
+			CHECK(false);
+		}
+	}
+}
+
+// A pool that breaks nothing must produce no findings at all, or every real DDOP becomes noise.
+static void check_clean_pool_is_silent()
+{
+	CHECK(validate_ddop(*make_clean_pool(4)).empty());
+}
+
+// The stack stops at the first broken reference. The whole point of the validator is that it does not.
+static void check_every_error_is_reported()
+{
+	isobus::DeviceDescriptorObjectPool pool(4);
+	std::array<std::uint8_t, 7> localization = { 'e', 'n', 0x50, 0x00, 0x00, 0x00, 0xFF };
+
+	CHECK(pool.add_device("Sprayer", "1.0", "SN1", "STRUCT1", localization, {}, 0xA000000000000000));
+	CHECK(pool.add_device_element("Root", 0, 0, DeviceElementObject::Type::Device, 1));
+	CHECK(pool.add_device_element("No parent", 1, 0, DeviceElementObject::Type::Function, 2));
+	CHECK(pool.add_device_element("Ghost parent", 2, 900, DeviceElementObject::Type::Function, 3));
+	CHECK(pool.add_device_element("Parent is process data", 3, 10, DeviceElementObject::Type::Function, 4));
+	CHECK(pool.add_device_process_data("Ghost presentation", 70, 900, 0x00, 0x01, 10));
+	CHECK(pool.add_device_process_data("Presentation is an element", 71, 1, 0x00, 0x01, 11));
+	std::static_pointer_cast<DeviceElementObject>(pool.get_object_by_id(2))->set_parent_object(0xFFFF);
+
+	auto root = std::static_pointer_cast<DeviceElementObject>(pool.get_object_by_id(1));
+	root->add_reference_to_child_object(99);
+	root->add_reference_to_child_object(2);
+
+	std::vector<std::uint8_t> binaryPool;
+	auto findings = validate_ddop(pool);
+
+	CHECK(!pool.generate_binary_object_pool(binaryPool));
+
+	// The stack stops at whichever of these it reaches first, so each one has to be named here to stay covered
+	check_every_rule_fires(findings, { "has no parent object", "as its parent, but no object in the pool has that ID", "as its parent. Only the device object or another device element", "references child object 99, but no object in the pool has that ID", "as a child. A device element may only have", "as its value presentation, but no object in the pool has that ID", "as its value presentation. Only a device value presentation object" });
+	CHECK(7 == count(findings, DDOPValidationFinding::Severity::Error));
+}
+
+// A parent cycle serializes cleanly, so it can only ever be a warning.
+static void check_parent_cycle_is_a_warning()
+{
+	isobus::DeviceDescriptorObjectPool pool(4);
+	std::array<std::uint8_t, 7> localization = { 'e', 'n', 0x50, 0x00, 0x00, 0x00, 0xFF };
+
+	CHECK(pool.add_device("Sprayer", "1.0", "SN1", "STRUCT1", localization, {}, 0xA000000000000000));
+	CHECK(pool.add_device_element("Root", 0, 0, DeviceElementObject::Type::Device, 1));
+	CHECK(pool.add_device_element("A", 1, 3, DeviceElementObject::Type::Function, 2));
+	CHECK(pool.add_device_element("B", 2, 2, DeviceElementObject::Type::Function, 3));
+
+	std::vector<std::uint8_t> binaryPool;
+	auto findings = validate_ddop(pool);
+
+	CHECK(pool.generate_binary_object_pool(binaryPool));
+	CHECK(0 == count(findings, DDOPValidationFinding::Severity::Error));
+	CHECK(2 == times_fired(findings, "cycle of parent references"));
+}
+
+// A TC reads the default set by requesting DDI 0xDFFF, so marking members without it is unaskable.
+// All 9 corpus pools that mark a member carry that object on element 0 offering every trigger method.
+static void check_default_set_needs_its_request_object()
+{
+	auto missing = make_clean_pool(4);
+	CHECK(std::static_pointer_cast<DeviceElementObject>(missing->get_object_by_id(1))->remove_reference_to_child_object(4));
+	CHECK(missing->remove_object_by_id(4));
+	CHECK(fires(validate_ddop(*missing), "no object for DDI 57343"));
+
+	auto wrongTriggers = make_clean_pool(4);
+	std::static_pointer_cast<DeviceProcessDataObject>(wrongTriggers->get_object_by_id(4))->set_trigger_methods_bitfield(0x01);
+	CHECK(fires(validate_ddop(*wrongTriggers), "has to offer every trigger method"));
+
+	auto wrongElement = make_clean_pool(4);
+	CHECK(std::static_pointer_cast<DeviceElementObject>(wrongElement->get_object_by_id(1))->remove_reference_to_child_object(4));
+	CHECK(wrongElement->add_device_element("Bin", 7, 1, DeviceElementObject::Type::Bin, 5));
+	std::static_pointer_cast<DeviceElementObject>(wrongElement->get_object_by_id(5))->add_reference_to_child_object(4);
+	CHECK(fires(validate_ddop(*wrongElement), "hangs off element number 7"));
+}
+
+// A TC addresses the device itself as element 0. Every pool in the corpus numbers its device element 0.
+static void check_device_element_is_number_zero()
+{
+	auto pool = make_clean_pool(4);
+	std::static_pointer_cast<DeviceElementObject>(pool->get_object_by_id(1))->set_element_number(1);
+	CHECK(fires(validate_ddop(*pool), "has the type Device but element number 1"));
+}
+
+// The version 4 limit is 32 UTF-8 characters. The stack's 128 bytes is what 32 four-byte characters take.
+static void check_version_4_designator_counts_characters()
+{
+	auto tooMany = make_clean_pool(4);
+	tooMany->get_object_by_id(1)->set_designator(std::string(33, 'a'));
+	CHECK(fires(validate_ddop(*tooMany), "33 UTF-8 characters"));
+
+	auto atTheLimit = make_clean_pool(4);
+	atTheLimit->get_object_by_id(1)->set_designator(std::string(32, 'a'));
+	CHECK(validate_ddop(*atTheLimit).empty());
+
+	// 32 two-byte characters is 64 bytes, which the old byte-only rule would have let through and this one must too
+	std::string accented;
+	for (int i = 0; i < 32; i++)
+	{
+		accented += "\xC3\xA9";
+	}
+	auto multiByte = make_clean_pool(4);
+	multiByte->get_object_by_id(1)->set_designator(accented);
+	CHECK(validate_ddop(*multiByte).empty());
+}
+
+// A scale of NaN or infinity passes a "scale <= 0" test, so it needs a test of its own.
+static void check_non_finite_scale_is_reported()
+{
+	auto pool = make_clean_pool(4);
+	std::static_pointer_cast<DeviceValuePresentationObject>(pool->get_object_by_id(2))->set_scale(std::numeric_limits<float>::quiet_NaN());
+	CHECK(fires(validate_ddop(*pool), "scale that is not a finite number"));
+
+	auto infinite = make_clean_pool(4);
+	std::static_pointer_cast<DeviceValuePresentationObject>(infinite->get_object_by_id(2))->set_scale(std::numeric_limits<float>::infinity());
+	CHECK(fires(validate_ddop(*infinite), "scale that is not a finite number"));
+}
+
+// The stack builds every device object with ID 0, so a device object ID does not survive being read back.
+// Counting objects cannot see that; comparing the bytes can.
+static void check_read_back_sees_a_dropped_field()
+{
+	auto pool = make_clean_pool(4);
+	pool->get_object_by_id(0)->set_object_id(5);
+	std::static_pointer_cast<DeviceElementObject>(pool->get_object_by_id(1))->set_parent_object(5);
+
+	std::vector<std::uint8_t> binaryPool;
+	CHECK(pool->generate_binary_object_pool(binaryPool));
+	CHECK(fires(validate_ddop(*pool), "cannot be serialized again after being read back"));
+
+	// A version 3 designator over 32 bytes is truncated on the way back in, which leaves the count untouched
+	auto truncated = make_clean_pool(3);
+	truncated->get_object_by_id(1)->set_designator(std::string(40, 'a'));
+
+	std::vector<std::uint8_t> otherPool;
+	CHECK(truncated->generate_binary_object_pool(otherPool));
+	CHECK(fires(validate_ddop(*truncated), "does not reproduce the same bytes"));
+}
+
+// Every warning rule fires at least once, so none of them is dead code.
+static void print_rule_coverage()
+{
+	isobus::DeviceDescriptorObjectPool pool(3);
+	std::array<std::uint8_t, 7> badLocalization = { 'e', 'n', 0x50, 0, 0, 0, 0x00 };
+
+	pool.add_device("", "sw", "sn", "", badLocalization, {}, 0);
+	auto device = std::static_pointer_cast<DeviceObject>(pool.get_object_by_id(0));
+	device->set_structure_label("TOOLONGLABEL");
+	device->set_extended_structure_label(std::vector<std::uint8_t>(40, 'x'));
+
+	pool.add_device_element("Root", 5000, 0, DeviceElementObject::Type::Device, 1);
+	pool.add_device_element("Second root", 5000, 0, DeviceElementObject::Type::Device, 2);
+	pool.add_device_element("A", 1, 4, DeviceElementObject::Type::Function, 3);
+	pool.add_device_element("B", 2, 3, DeviceElementObject::Type::Function, 4);
+	pool.add_device_process_data("Ghost", 40000, 0xFFFF, 0x86, 0xE1, 10);
+	pool.add_device_property("Prop", 1, 0xFFFF, 0xFFFF, 11);
+	std::static_pointer_cast<DevicePropertyObject>(pool.get_object_by_id(11))->set_ddi(0xFFFF);
+	pool.add_device_value_presentation("unit", 0, 0.0f, 99, 12);
+	pool.add_device_value_presentation("w", 0, 1.0f, 0, 13);
+
+	// Set after adding, because add_device_value_presentation truncates a long designator itself
+	pool.get_object_by_id(13)->set_designator(std::string(40, 'w'));
+	pool.get_object_by_id(1)->set_designator(std::string(300, 'z'));
+
+	auto findings = validate_ddop(pool);
+
+	printf("\n=== every rule, on one deliberately broken pool ===\n");
+	for (const auto &finding : findings)
+	{
+		printf("  %s %s\n", (DDOPValidationFinding::Severity::Error == finding.severity) ? "ERROR  " : "WARNING", finding.message.c_str());
+	}
+	check_every_rule_fires(findings, { "sits in a cycle of parent references", "element number 5000", "is used by device elements", "structure label is 12 bytes", "extended structure label is 40 bytes", "only a version 4 TC reads", "localization label is reserved", "ISO NAME is 0", "byte limit for a version 3 pool", "stored in a single byte", "all have the type Device", "all name the device object as their parent", "has the type Device but element number", "bundled copy of the ISO 11783-11 data dictionary", "which ISO 11783-11 reserves", "reserved bits in its properties bitfield", "reserved bits in its trigger methods bitfield", "both settable and a control source", "control source, which only a version 4 TC", "scale of 0.000000", "decimals", "not a child of any device element" });
+}
+
+int main(int argc, char **argv)
+{
+	check_clean_pool_is_silent();
+	check_every_error_is_reported();
+	check_parent_cycle_is_a_warning();
+	check_default_set_needs_its_request_object();
+	check_device_element_is_number_zero();
+	check_version_4_designator_counts_characters();
+	check_non_finite_scale_is_reported();
+	check_read_back_sees_a_dropped_field();
+	print_rule_coverage();
+
+	// Any file paths on the command line are loaded and dumped too, which is how the rules were checked
+	// against a corpus of real vendor DDOPs that cannot be redistributed here
+	for (int i = 1; i < argc; i++)
+	{
+		auto data = isobus::IOPFileInterface::read_iop_file(argv[i]);
+		auto pool = std::unique_ptr<isobus::DeviceDescriptorObjectPool>(new isobus::DeviceDescriptorObjectPool());
+		bool loaded = false;
+
+		for (std::uint8_t version : { 3, 4 })
+		{
+			pool->set_task_controller_compatibility_level(version);
+			loaded = pool->deserialize_binary_object_pool(data, isobus::NAME(0));
+
+			if (loaded)
+			{
+				break;
+			}
+			pool.reset(new isobus::DeviceDescriptorObjectPool());
+		}
+		printf("\n=== %s ===\n", argv[i]);
+
+		if (!loaded)
+		{
+			printf("  could not be loaded as a version 3 or version 4 pool\n");
+			continue;
+		}
+
+		for (const auto &finding : validate_ddop(*pool))
+		{
+			printf("  %s %s\n", (DDOPValidationFinding::Severity::Error == finding.severity) ? "ERROR  " : "WARNING", finding.message.c_str());
+		}
+	}
+	printf("\nAll assertions passed.\n");
+	return 0;
+}


### PR DESCRIPTION
This is a BIG upgrade towards the DDOP validation. Right now "Check for Errors" mostly tells us whether the pool could be built. If `generate_binary_object_pool()` fails we get one message with the stack log, and if it succeeds we get "no errors", apart from the duplicate element number warning from #17 which goes to the log. So the pool can still have plenty in it which a TC will not accept and the button says nothing about it. I hit this a few times while working on other DDOP issues, so I wanted it to actually say what is wrong and on which object.

This adds the checks behind that button. The findings are split into two severities and they mean different things:
- Error means the pool can not be serialized at all. `generate_binary_object_pool()` will fail.
- Warning means the pool serializes fine, but a TC may reject it or read it as something different than what you built.

The popup now shows the counts, then the findings in a scrollable list, errors first and in red, warnings in yellow. Each finding names the object by ID and designator and says why it matters, so you don't have to open the standard to know what to do about it. The stack log is still shown below when serialization fails.

I kept the two severities strict, because a warning which is really an error is annoying in the other direction too. If it serializes, it is a warning. Currently we test all of the scenarios explained below for validation.

# Errors
1. A device element has no parent object.
2.  A device element names a parent object ID which is not in the pool.
3. A device element's parent is not the device object and not another device element.
4. A device element references a child object ID which is not in the pool.
5. A device element has a child which is not device process data and not a device property.
6. A process data or property object names a value presentation ID which is not in the pool.
7. A process data or property object's value presentation is not a device value presentation object.
8. Serialization failed for some reason none of the checks above covers. The stack log is attached to this one.


# Warnings
**Device object**
1. The pool has no device object.
2. The pool has more than one device object.
3. The structure label is empty, so it is sent as seven spaces. A TC keys its cached copy of the pool on this label, so every pool which leaves it empty looks like the same one.
4. The ISO NAME is 0. A TC compares it against the NAME of the client which uploads the pool.
5. Byte 7 of the localization label is not 0xFF.
6. An extended structure label is set, but the pool version is below 4. Only a version 4 TC reads it.
7. The extended structure label is longer than ISO 11783-10 allows.
8. The structure label is longer than ISO 11783-10 allows. The stack truncates it.

**String lengths** (every designator, plus the device serial number and software version)

9. Longer than 255 bytes. The length is stored in one byte, so a TC reads the wrong length and every object after it in the pool becomes unreadable.
10. Longer than 32 bytes in a version 1 to 3 pool.
11. Longer than 128 bytes in a version 4 pool.
12. More than 32 UTF-8 characters in a version 4 pool. 128 bytes is what 32 four-byte characters take, it is not a longer allowance.

**Element numbers**

13. An element number above 4095. A process data message carries it in 12 bits.
14. Two or more device elements use the same element number. This is the check from #17, it moved into the new validator.

**Element tree**

15. An element has the type Device but a non-zero element number. A TC addresses the device itself as element 0.
16. An element sits in a cycle of parent references, so following its parents never reaches the device object.
17. No element has the type Device.
18. More than one element has the type Device.
19. More than one element names the device object as its parent, so the tree has more than one root.

**DDIs (process data and property objects)**

20. A DDI which ISO 11783-11 reserves.
21. A DDI which is not in the bundled copy of the ISO 11783-11 dictionary. Either it is not defined, or our copy predates it.

**Process data flags**

22. Reserved bits set in the properties bitfield. Only the first three are defined.
23. Marked as a control source in a pool below version 4.
24. Marked settable and control source at the same time. ISO 11783-10 makes those mutually exclusive.
25. Reserved bits set in the trigger methods bitfield. Only the first five are defined.

**Default process data set**

26. The request default object (DDI 57343, 0xDFFF) does not offer every trigger method.
27. Objects are marked as members of the default set, but there is no DDI 57343 object, so nothing will ever ask for those values.
28. The request default object hangs off an element other than element 0. A TC asks element 0 for it.
29. The request default object is not a child of any device element.

**Value presentations**

30. The scale is not a finite number. It also does not survive being written to the pool as a float.
31. The scale is 0, so nothing but the offset would ever be displayed.
32. More than 7 decimals.

**Reachability**

33. A process data or property object which is not a child of any device element, so a TC can never address it.

**Read back**

34. The serialized pool can not be read back by the ISOBUS stack this app is built on.
35. Reading it back gives a different number of objects than the pool has.
36. The pool read back can not be serialized again.
37. Serializing the pool read back does not reproduce the same bytes, so at least one field does not survive the trip.

## How has this been tested?
There is a new ddop_validator_test target which builds a clean pool, breaks it in a specific way for each rule, and checks that the rule fires and that a clean pool produces no findings at all. It names every rule it expects instead of counting findings, so a rule which stops firing is a failure and not just a different number. CI builds the target too.

```
cmake -S . -B build
cmake --build build
ctest --test-dir build --output-on-failure
```